### PR TITLE
Alertmanager HA

### DIFF
--- a/prometheus/docker-compose.yml
+++ b/prometheus/docker-compose.yml
@@ -127,7 +127,7 @@ services:
           memory: 64M
 
   alertmanager:
-    image: prom/alertmanager
+    image: jmb12686/alertmanager-swarm
     networks:
       - net
     environment:
@@ -141,8 +141,49 @@ services:
       - "--web.external-url=http://raspi-swarm.home.local:9093"
       - '--config.file=/etc/alertmanager/alertmanager.yml'
       - '--storage.path=/alertmanager'
+      - '--cluster.listen-address=0.0.0.0:8001'
+      - '--cluster.peer=tasks.alertmanager-2:8001' 
+      - '--log.level=debug'     
+      # - '--cluster.advertise-address=' --> This arg gets set in the jmb12686/alertmanager-swarm image entry-point script.      
+                                           # It effectively gets set to the eth1 interface IP @ port 8001 to support Swarm networking  
     ports:
       - 9093:9093
+    volumes:
+      - alertmanager:/alertmanager
+    deploy:
+      mode: replicated
+      replicas: 1
+      placement:
+        constraints:
+          - node.role == manager
+      resources:
+        limits:
+          memory: 128M
+        reservations:
+          memory: 64M
+
+  alertmanager-2:
+    image: jmb12686/alertmanager-swarm
+    networks:
+      - net
+    environment:
+      - SLACK_URL=${SLACK_URL:-https://hooks.slack.com/services/TOKEN}
+      - SLACK_CHANNEL=${SLACK_CHANNEL:-general}
+      - SLACK_USER=${SLACK_USER:-alertmanager}
+    configs:
+      - source: alert_manager
+        target: /etc/alertmanager/alertmanager.yml
+    command:
+      - "--web.external-url=http://raspi-swarm.home.local:9093"
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
+      - '--cluster.listen-address=0.0.0.0:8001'
+      - '--cluster.peer=alertmanager:8001'      
+      - '--log.level=debug'      
+      # - '--cluster.advertise-address=' --> This arg gets set in the jmb12686/alertmanager-swarm image entry-point script.      
+                                           # This gets set to the eth1 interface IP @ port 8001 to support Swarm networking       
+    ports:
+      - 9092:9093
     volumes:
       - alertmanager:/alertmanager
     deploy:

--- a/prometheus/docker-compose.yml
+++ b/prometheus/docker-compose.yml
@@ -142,8 +142,8 @@ services:
       - '--config.file=/etc/alertmanager/alertmanager.yml'
       - '--storage.path=/alertmanager'
       - '--cluster.listen-address=0.0.0.0:8001'
-      - '--cluster.peer=tasks.alertmanager-2:8001' 
-      - '--log.level=debug'     
+      - '--cluster.peer=tasks.alertmanager:8001'      
+      # - '--log.level=debug'     
       # - '--cluster.advertise-address=' --> This arg gets set in the jmb12686/alertmanager-swarm image entry-point script.      
                                            # It effectively gets set to the eth1 interface IP @ port 8001 to support Swarm networking  
     ports:
@@ -152,43 +152,7 @@ services:
       - alertmanager:/alertmanager
     deploy:
       mode: replicated
-      replicas: 1
-      placement:
-        constraints:
-          - node.role == manager
-      resources:
-        limits:
-          memory: 128M
-        reservations:
-          memory: 64M
-
-  alertmanager-2:
-    image: jmb12686/alertmanager-swarm
-    networks:
-      - net
-    environment:
-      - SLACK_URL=${SLACK_URL:-https://hooks.slack.com/services/TOKEN}
-      - SLACK_CHANNEL=${SLACK_CHANNEL:-general}
-      - SLACK_USER=${SLACK_USER:-alertmanager}
-    configs:
-      - source: alert_manager
-        target: /etc/alertmanager/alertmanager.yml
-    command:
-      - "--web.external-url=http://raspi-swarm.home.local:9093"
-      - '--config.file=/etc/alertmanager/alertmanager.yml'
-      - '--storage.path=/alertmanager'
-      - '--cluster.listen-address=0.0.0.0:8001'
-      - '--cluster.peer=alertmanager:8001'      
-      - '--log.level=debug'      
-      # - '--cluster.advertise-address=' --> This arg gets set in the jmb12686/alertmanager-swarm image entry-point script.      
-                                           # This gets set to the eth1 interface IP @ port 8001 to support Swarm networking       
-    ports:
-      - 9092:9093
-    volumes:
-      - alertmanager:/alertmanager
-    deploy:
-      mode: replicated
-      replicas: 1
+      replicas: 2
       placement:
         constraints:
           - node.role == manager

--- a/prometheus/prometheus/conf/prometheus.yml
+++ b/prometheus/prometheus/conf/prometheus.yml
@@ -16,15 +16,6 @@ alerting:
         - 'tasks.alertmanager'
         type: 'A'
         port: 9093  
-  # - static_configs:
-  #   - targets:
-  #     - alertmanager:9093
-  #     - alertmanager-2:9093
-    # - dns_sd_configs:
-    #   - names:
-    #     - 'tasks.alertmanager'
-    #     type: 'A'
-    #     port: 9093
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/prometheus/prometheus/conf/prometheus.yml
+++ b/prometheus/prometheus/conf/prometheus.yml
@@ -14,6 +14,12 @@ alerting:
   - static_configs:
     - targets:
       - alertmanager:9093
+      - alertmanager-2:9093
+    # - dns_sd_configs:
+    #   - names:
+    #     - 'tasks.alertmanager'
+    #     type: 'A'
+    #     port: 9093
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/prometheus/prometheus/conf/prometheus.yml
+++ b/prometheus/prometheus/conf/prometheus.yml
@@ -11,10 +11,15 @@ rule_files:
 
 alerting:
   alertmanagers:
-  - static_configs:
-    - targets:
-      - alertmanager:9093
-      - alertmanager-2:9093
+    - dns_sd_configs:
+      - names:
+        - 'tasks.alertmanager'
+        type: 'A'
+        port: 9093  
+  # - static_configs:
+  #   - targets:
+  #     - alertmanager:9093
+  #     - alertmanager-2:9093
     # - dns_sd_configs:
     #   - names:
     #     - 'tasks.alertmanager'


### PR DESCRIPTION
Enable high availability alertmanager cluster using custom built image to support swarm internal overlay networking.

alertmanager docker service has 2 replicas, and service discovery is utilized by prometheus->alertmanager and for setting the alertmanager cluster.peer-address.  

Custom jmb12686/alertmanager-swarm implementation is used to support Docker Swarm internal overlay networking, and the configuration/setting of the --cluster.advertise-address.  Without the custom image, the alertmanager's keep connecting and dropping every couple seconds, never forming a healthy cluster state.  

The custom image (see more in the github.com/jmb12686/docker-swarm-alertmanager repo) sets the cluster advertise-address to the container's eth1 IP.