### PR TITLE
Add Dead Man's Snitch webhook alert to monitor the alerting subsystem…

### DIFF
--- a/prometheus/alertmanager/conf/alertmanager.yml
+++ b/prometheus/alertmanager/conf/alertmanager.yml
@@ -1,9 +1,22 @@
 route:
   group_by: [...]
-  receiver: 'email-me'
+  receiver: 'default-receiver'
+  # All alerts that do not match the following child routes
+  # will remain at the root node and be dispatched to 'default-receiver'.  
+  routes:
+  # All alerts with alertname=DeadMansSnitch
+  # are dispatched to the deadmanssnitch receiver webhook
+  - match:
+      alertname: DeadMansSnitch
+    receiver: deadmanssnitch
+    repeat_interval: 5m
 
 receivers:
-  - name: 'email-me'
+  - name: 'deadmanssnitch'
+    webhook_configs:
+    - send_resolved: false
+      url: 'https://nosnch.in/SNITCH_URL'
+  - name: 'default-receiver'
     email_configs:
     - send_resolved: true
       to: $EMAIL_TO_ACCOUNT

--- a/prometheus/docker-compose.yml
+++ b/prometheus/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.7"
 
 networks:
   net:
@@ -11,10 +11,15 @@ volumes:
     alertmanager: {}
 
 configs:
+  prometheus:
+    name: prometheus-${CONFIG_VERSION:-0}
+    file: ./prometheus/conf/prometheus.yml  
   node_rules:
     file: ./prometheus/rules/swarm_node.rules.yml
   task_rules:
     file: ./prometheus/rules/swarm_task.rules.yml
+  meta_rules:
+    file: ./prometheus/rules/snitch.rules.yml
   grafana_datasource:
     file: ./grafana/datasources/prometheus.yaml
   grafana_provisioning_dashboards:
@@ -26,9 +31,8 @@ configs:
   grafana_dashboards_services:
     file: ./grafana/dashboards/swarmprom-services-dash.json
   alert_manager:
+    name: alert_manager-${CONFIG_VERSION:-0}
     file: ./alertmanager/conf/prod.alertmanager.yml
-  prometheus:
-    file: ./prometheus/conf/prometheus.yml
   blackbox_exporter:
     file: ./blackbox-exporter/blackbox.yml
   
@@ -205,6 +209,8 @@ services:
         target: /etc/prometheus/swarm_node.rules.yml
       - source: task_rules
         target: /etc/prometheus/swarm_task.rules.yml
+      - source: meta_rules
+        target: /etc/prometheus/snitch.rules.yml
     ports:
       - 9090:9090
     deploy:

--- a/prometheus/prometheus/conf/prometheus.yml
+++ b/prometheus/prometheus/conf/prometheus.yml
@@ -8,6 +8,7 @@ global:
 rule_files:
   - "swarm_node.rules.yml"
   - "swarm_task.rules.yml"
+  - "snitch.rules.yml"
 
 alerting:
   alertmanagers:

--- a/prometheus/prometheus/rules/snitch.rules.yml
+++ b/prometheus/prometheus/rules/snitch.rules.yml
@@ -1,0 +1,11 @@
+groups:
+- name: meta
+  rules:
+  - alert: DeadMansSnitch
+    expr: vector(1)
+    labels:
+      severity: critical
+    annotations:
+      description: This is a DeadMansSnitch meant to ensure that the entire Alerting
+        pipeline is functional.
+      summary: Alerting DeadMansSnitch


### PR DESCRIPTION
1) Add Dead Man's Snitch (https://deadmanssnitch.com/) webhook alert to monitor the overall prometheus alerting subsystem
2) Add versioning tags to docker config names in prometheus mon stack.  See Prometheus README.md in this repo to set version env variable.  This allows updating configs / redeployment of a docker stack without having to delete or manually alter services.